### PR TITLE
fix: prevent description editor from handling key combos not directed at it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * feat: replaced old icon with a new one (shoutout to my wife Sofia who created
   it!)
 * feat: added links to Toggl ToS and Privacy Policy
+* bugfix: description editor no longer handles keyboard shortcuts when not focused.
 
 ## 0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+## 0.2.4 (unreleased)
+
+* bugfix: description editor no longer handles keyboard shortcuts when not focused.
+
 ## 0.2.3
 
 * feat: replaced old icon with a new one (shoutout to my wife Sofia who created
   it!)
 * feat: added links to Toggl ToS and Privacy Policy
-* bugfix: description editor no longer handles keyboard shortcuts when not focused.
 
 ## 0.2.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5399,7 +5399,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toggl-tracker"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-std",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ license = "MIT"
 name = "toggl-tracker"
 readme = "README.md"
 repository = "https://github.com/sterliakov/toggl"
-version = "0.2.3"
+version = "0.2.4"
 
 [profile.release]
 lto = true

--- a/src/widgets/text_editor_ext.rs
+++ b/src/widgets/text_editor_ext.rs
@@ -45,6 +45,9 @@ impl TextEditorExt {
     pub fn view<'a>(&'a self) -> TextEditor<'a, PlainText, TextEditorMessage> {
         text_editor(&self.content)
             .key_binding(|press| {
+                if !matches!(press.status, text_editor::Status::Focused) {
+                    return None;
+                }
                 match press.key.as_ref() {
                     keyboard::Key::Named(NamedKey::Backspace)
                     | keyboard::Key::Character("w")


### PR DESCRIPTION
When a keyboard shortcut is used in another field (start/end date), it was wrongly applied to description editor as well.