### PR TITLE
Implement optimistic updates to reduce API call count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.4 (unreleased)
+## 0.2.4
 
 * bugfix: description editor no longer handles keyboard shortcuts when not focused.
 * feat: implement optimistic update to make fewer API requests and stay under API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.2.4 (unreleased)
 
 * bugfix: description editor no longer handles keyboard shortcuts when not focused.
+* feat: implement optimistic update to make fewer API requests and stay under API
+  rate limits.
 
 ## 0.2.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -3700,9 +3700,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/src/entities/related_info.rs
+++ b/src/entities/related_info.rs
@@ -4,15 +4,15 @@ use serde::Deserialize;
 use super::WorkspaceId;
 use crate::entities::{Preferences, Project, Workspace};
 use crate::time_entry::TimeEntry;
-use crate::utils::{Client, NetResult};
+use crate::utils::{maybe_vec_deserialize, Client, NetResult};
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct ExtendedMe {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "maybe_vec_deserialize")]
     pub projects: Vec<Project>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "maybe_vec_deserialize")]
     pub workspaces: Vec<Workspace>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "maybe_vec_deserialize")]
     pub time_entries: Vec<TimeEntry>,
     #[serde(default)]
     pub beginning_of_week: u8,

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,13 +344,13 @@ impl App {
             },
             Screen::EditEntry(screen) => match message {
                 Message::EditTimeEntryProxy(
-                    EditTimeEntryMessage::Completed,
+                    EditTimeEntryMessage::Completed(change),
                 ) => {
-                    self.screen = Screen::Loading;
-                    return Command::perform(State::load(), Message::Loaded);
+                    self.state.apply_change(change);
+                    self.screen = Screen::Loaded(TemporaryState::default());
                 }
                 Message::EditTimeEntryProxy(EditTimeEntryMessage::Abort) => {
-                    self.screen = Screen::Loaded(TemporaryState::default())
+                    self.screen = Screen::Loaded(TemporaryState::default());
                 }
                 Message::EditTimeEntryProxy(msg) => {
                     return screen

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,8 @@ impl App {
                     RunningEntryMessage::SyncUpdate(change) => {
                         if self.state.apply_change(change).is_err() {
                             return Command::done(Message::Reload);
+                        } else {
+                            return self.update_icon();
                         }
                     }
                     other => {
@@ -351,6 +353,8 @@ impl App {
                     self.screen = Screen::Loaded(TemporaryState::default());
                     if self.state.apply_change(change).is_err() {
                         return Command::done(Message::Reload);
+                    } else {
+                        return self.update_icon();
                     }
                 }
                 Message::EditTimeEntryProxy(EditTimeEntryMessage::Abort) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,8 +264,10 @@ impl App {
                     RunningEntryMessage::Error(err) => {
                         return Command::done(Message::Error(err));
                     }
-                    RunningEntryMessage::Reload => {
-                        return Command::done(Message::Reload);
+                    RunningEntryMessage::SyncUpdate(change) => {
+                        if self.state.apply_change(change).is_err() {
+                            return Command::done(Message::Reload);
+                        }
                     }
                     other => {
                         return temp_state
@@ -346,8 +348,10 @@ impl App {
                 Message::EditTimeEntryProxy(
                     EditTimeEntryMessage::Completed(change),
                 ) => {
-                    self.state.apply_change(change);
                     self.screen = Screen::Loaded(TemporaryState::default());
+                    if self.state.apply_change(change).is_err() {
+                        return Command::done(Message::Reload);
+                    }
                 }
                 Message::EditTimeEntryProxy(EditTimeEntryMessage::Abort) => {
                     self.screen = Screen::Loaded(TemporaryState::default());

--- a/src/screens/edit_time_entry.rs
+++ b/src/screens/edit_time_entry.rs
@@ -6,7 +6,7 @@ use iced::{keyboard, Element, Fill, Length, Task as Command};
 
 use crate::customization::Customization;
 use crate::entities::MaybeProject;
-use crate::state::State;
+use crate::state::{EntryEditAction, EntryEditInfo, State};
 use crate::time_entry::TimeEntry;
 use crate::utils::{Client, ExactModifiers};
 use crate::widgets::{
@@ -35,7 +35,7 @@ pub enum EditTimeEntryMessage {
     Submit,
     Delete,
     Abort,
-    Completed,
+    Completed(EntryEditInfo),
     Error(String),
 }
 
@@ -189,7 +189,7 @@ impl EditTimeEntry {
                 ));
             }
             EditTimeEntryMessage::Abort => {}
-            EditTimeEntryMessage::Completed => {}
+            EditTimeEntryMessage::Completed(_) => {}
             EditTimeEntryMessage::Error(err) => {
                 self.error = Some(err);
             }
@@ -227,7 +227,10 @@ impl EditTimeEntry {
         {
             EditTimeEntryMessage::Error(message)
         } else {
-            EditTimeEntryMessage::Completed
+            EditTimeEntryMessage::Completed(EntryEditInfo {
+                entry,
+                action: EntryEditAction::Update,
+            })
         }
     }
 
@@ -241,7 +244,10 @@ impl EditTimeEntry {
         {
             EditTimeEntryMessage::Error(message)
         } else {
-            EditTimeEntryMessage::Completed
+            EditTimeEntryMessage::Completed(EntryEditInfo {
+                entry,
+                action: EntryEditAction::Delete,
+            })
         }
     }
 }

--- a/src/screens/edit_time_entry.rs
+++ b/src/screens/edit_time_entry.rs
@@ -127,33 +127,37 @@ impl EditTimeEntry {
         message: EditTimeEntryMessage,
         customization: &Customization,
     ) -> Command<EditTimeEntryMessage> {
+        use EditTimeEntryMessage::*;
+
         match message {
-            EditTimeEntryMessage::DescriptionEdited(action) => {
+            DescriptionEdited(action) => {
                 self.description_editor.update(action);
             }
-            EditTimeEntryMessage::StartEdited(start) => {
+            StartEdited(DateTimeEditMessage::Finish)
+            | StopEdited(DateTimeEditMessage::Finish) => {
+                return Command::done(Submit);
+            }
+            StartEdited(start) => {
                 return self
                     .start_dt
                     .update(start, customization)
-                    .map(EditTimeEntryMessage::StartEdited)
+                    .map(StartEdited)
             }
-            EditTimeEntryMessage::StopEdited(stop) => {
+            StopEdited(stop) => {
                 return self
                     .stop_dt
                     .update(stop, customization)
-                    .map(EditTimeEntryMessage::StartEdited)
+                    .map(StartEdited)
             }
-            EditTimeEntryMessage::ProjectSelected(p) => {
+            ProjectSelected(p) => {
                 self.entry.project_id = p.id();
                 self.selected_project = p;
             }
-            EditTimeEntryMessage::Submit => {
+            Submit => {
                 match self.start_dt.get_value() {
-                    Err(e) => {
-                        return Command::done(EditTimeEntryMessage::Error(e))
-                    }
+                    Err(e) => return Command::done(Error(e)),
                     Ok(None) => {
-                        return Command::done(EditTimeEntryMessage::Error(
+                        return Command::done(Error(
                             "Start cannot be blank".to_string(),
                         ))
                     }
@@ -162,7 +166,7 @@ impl EditTimeEntry {
                 match self.stop_dt.get_value() {
                     Ok(stop) => self.entry.stop = stop,
                     Err(e) => {
-                        return Command::done(EditTimeEntryMessage::Error(e));
+                        return Command::done(Error(e));
                     }
                 };
                 let duration = self
@@ -170,7 +174,7 @@ impl EditTimeEntry {
                     .stop
                     .map(|stop| (stop - self.entry.start).num_seconds());
                 if duration.unwrap_or(1) < 0 {
-                    return Command::done(EditTimeEntryMessage::Error(
+                    return Command::done(Error(
                         "Start must come before end!".to_string(),
                     ));
                 };
@@ -182,15 +186,15 @@ impl EditTimeEntry {
                     self.api_token.clone(),
                 ));
             }
-            EditTimeEntryMessage::Delete => {
+            Delete => {
                 return Command::future(Self::delete(
                     self.entry.clone(),
                     self.api_token.clone(),
                 ));
             }
-            EditTimeEntryMessage::Abort => {}
-            EditTimeEntryMessage::Completed(_) => {}
-            EditTimeEntryMessage::Error(err) => {
+            Abort => {}
+            Completed(_) => {}
+            Error(err) => {
                 self.error = Some(err);
             }
         };

--- a/src/screens/edit_time_entry.rs
+++ b/src/screens/edit_time_entry.rs
@@ -226,15 +226,12 @@ impl EditTimeEntry {
         api_token: String,
     ) -> EditTimeEntryMessage {
         let client = &Client::from_api_token(&api_token);
-        if let Err(message) =
-            entry.save(client).await.map_err(|e| e.to_string())
-        {
-            EditTimeEntryMessage::Error(message)
-        } else {
-            EditTimeEntryMessage::Completed(EntryEditInfo {
-                entry,
+        match entry.save(client).await {
+            Err(e) => EditTimeEntryMessage::Error(e.to_string()),
+            Ok(new_entry) => EditTimeEntryMessage::Completed(EntryEditInfo {
+                entry: new_entry,
                 action: EntryEditAction::Update,
-            })
+            }),
         }
     }
 
@@ -243,10 +240,8 @@ impl EditTimeEntry {
         api_token: String,
     ) -> EditTimeEntryMessage {
         let client = &Client::from_api_token(&api_token);
-        if let Err(message) =
-            entry.delete(client).await.map_err(|e| e.to_string())
-        {
-            EditTimeEntryMessage::Error(message)
+        if let Err(message) = entry.delete(client).await {
+            EditTimeEntryMessage::Error(message.to_string())
         } else {
             EditTimeEntryMessage::Completed(EntryEditInfo {
                 entry,

--- a/src/state.rs
+++ b/src/state.rs
@@ -150,7 +150,8 @@ impl State {
                     self.running_entry = Some(change.entry.clone());
                 } else {
                     self.time_entries.insert(0, change.entry.clone());
-                    self.time_entries.sort_by_key(|e| e.start);
+                    self.time_entries
+                        .sort_by_key(|e| std::cmp::Reverse(e.start));
                 }
                 Ok(())
             }
@@ -190,7 +191,8 @@ impl State {
                         // Entry stopped
                         self.running_entry = None;
                         self.time_entries.insert(0, change.entry.clone());
-                        self.time_entries.sort_by_key(|e| e.start);
+                        self.time_entries
+                            .sort_by_key(|e| std::cmp::Reverse(e.start));
                         return Ok(());
                     }
                     _ => {}

--- a/src/time_entry.rs
+++ b/src/time_entry.rs
@@ -36,7 +36,6 @@ pub struct TimeEntry {
     pub stop: Option<DateTime<Local>>,
     #[serde(deserialize_with = "maybe_vec_deserialize")]
     pub tags: Vec<String>,
-    pub task_id: Option<u64>,
     pub user_id: u64,
     pub workspace_id: WorkspaceId,
 }

--- a/src/time_entry.rs
+++ b/src/time_entry.rs
@@ -115,7 +115,7 @@ impl TimeEntry {
         Client::check_status(&mut res).await
     }
 
-    pub async fn delete(self, client: &Client) -> NetResult<()> {
+    pub async fn delete(&self, client: &Client) -> NetResult<()> {
         debug!("Deleting a time entry {}...", self.id);
         let mut res = client
             .delete(format!(

--- a/src/time_entry.rs
+++ b/src/time_entry.rs
@@ -79,7 +79,7 @@ impl TimeEntry {
         }
     }
 
-    pub async fn save(&self, client: &Client) -> NetResult<()> {
+    pub async fn save(&self, client: &Client) -> NetResult<TimeEntry> {
         debug!("Updating a time entry {}...", self.id);
         let mut res = client
             .put(format!(
@@ -91,10 +91,11 @@ impl TimeEntry {
             .body_json(&self)?
             .send()
             .await?;
-        Client::check_status(&mut res).await
+        Client::check_status(&mut res).await?;
+        res.body_json().await
     }
 
-    pub async fn stop(&self, client: &Client) -> NetResult<()> {
+    pub async fn stop(&self, client: &Client) -> NetResult<TimeEntry> {
         debug!("Stopping a time entry {}...", self.id);
         assert!(self.stop.is_none());
         let mut res = client
@@ -106,7 +107,8 @@ impl TimeEntry {
             ))
             .send()
             .await?;
-        Client::check_status(&mut res).await
+        Client::check_status(&mut res).await?;
+        res.body_json().await
     }
 
     pub async fn delete(&self, client: &Client) -> NetResult<()> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,8 +5,10 @@ use chrono::{
 use iced::keyboard::Modifiers;
 
 mod client;
+mod serde;
 
 pub use client::{Client, Result as NetResult};
+pub use serde::maybe_vec_deserialize;
 
 pub fn duration_to_hms(duration: &Duration) -> String {
     let total_seconds = duration.num_seconds();

--- a/src/utils/serde.rs
+++ b/src/utils/serde.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Deserializer};
+
+pub fn maybe_vec_deserialize<'de, D: Deserializer<'de>, T: Deserialize<'de>>(
+    data: D,
+) -> Result<Vec<T>, D::Error> {
+    let maybe: Option<Vec<T>> = Deserialize::deserialize(data)?;
+    Ok(maybe.unwrap_or_default())
+}

--- a/src/widgets/date_time_widget.rs
+++ b/src/widgets/date_time_widget.rs
@@ -20,6 +20,8 @@ pub enum DateTimeEditMessage {
     OpenDatePicker,
     CloseDatePicker,
     SubmitDate(Date),
+    /// Should be handled externally: Enter pressed (submit)
+    Finish,
 }
 
 #[derive(Clone, Debug)]
@@ -60,7 +62,8 @@ impl DateTimeWidget {
         column![row![
             text_input(&self.input_label, &self.full_text)
                 .id(self.input_id.clone())
-                .on_input(DateTimeEditMessage::EditText),
+                .on_input(DateTimeEditMessage::EditText)
+                .on_submit(DateTimeEditMessage::Finish),
             self.date_picker(ref_time),
             self.time_picker(ref_time, customization),
         ]]
@@ -113,8 +116,10 @@ impl DateTimeWidget {
         message: DateTimeEditMessage,
         customization: &Customization,
     ) -> Command<DateTimeEditMessage> {
+        use DateTimeEditMessage::*;
+
         match message {
-            DateTimeEditMessage::EditText(text) => {
+            EditText(text) => {
                 if let Ok(Some(dt)) = customization.parse_datetime(&text) {
                     self.dt = Some(dt);
                     self.error = None;
@@ -124,30 +129,31 @@ impl DateTimeWidget {
                 }
                 self.full_text = text;
             }
-            DateTimeEditMessage::OpenTimePicker => {
+            OpenTimePicker => {
                 self.show_time_picker = true;
             }
-            DateTimeEditMessage::CloseTimePicker => {
+            CloseTimePicker => {
                 self.show_time_picker = false;
             }
-            DateTimeEditMessage::SubmitTime(time) => {
+            SubmitTime(time) => {
                 self.dt = Some(with_time(self.dt, time, Local::now));
                 self.full_text = customization.format_datetime(&self.dt);
                 self.error = None;
                 self.show_time_picker = false;
             }
-            DateTimeEditMessage::OpenDatePicker => {
+            OpenDatePicker => {
                 self.show_date_picker = true;
             }
-            DateTimeEditMessage::CloseDatePicker => {
+            CloseDatePicker => {
                 self.show_date_picker = false;
             }
-            DateTimeEditMessage::SubmitDate(date) => {
+            SubmitDate(date) => {
                 self.dt = Some(with_date(self.dt, date, Local::now));
                 self.full_text = customization.format_datetime(&self.dt);
                 self.error = None;
                 self.show_date_picker = false;
             }
+            Finish => {}
         };
         Command::none()
     }

--- a/src/widgets/running_entry.rs
+++ b/src/widgets/running_entry.rs
@@ -119,8 +119,8 @@ impl RunningEntry {
                         let client = Client::from_api_token(&token);
                         match entry.stop(&client).await {
                             Err(e) => Error(e.to_string()),
-                            Ok(_) => SyncUpdate(EntryEditInfo {
-                                action: EntryEditAction::Create,
+                            Ok(entry) => SyncUpdate(EntryEditInfo {
+                                action: EntryEditAction::Update,
                                 entry,
                             }),
                         }

--- a/src/widgets/running_entry.rs
+++ b/src/widgets/running_entry.rs
@@ -3,7 +3,7 @@ use iced::widget::{button, column, container, row, text, text_input};
 use iced::{Color, Length, Task as Command};
 use log::{info, warn};
 
-use crate::state::State;
+use crate::state::{EntryEditAction, EntryEditInfo, State};
 use crate::time_entry::TimeEntry;
 use crate::utils::Client;
 use crate::widgets::icon_button;
@@ -22,7 +22,7 @@ pub enum RunningEntryMessage {
     // Public
     StartEditing(Box<TimeEntry>),
     Error(String),
-    Reload,
+    SyncUpdate(EntryEditInfo),
 }
 
 impl RunningEntry {
@@ -100,7 +100,10 @@ impl RunningEntry {
                     );
                     match fut.await {
                         Err(e) => Error(e.to_string()),
-                        Ok(_) => Reload,
+                        Ok(entry) => SyncUpdate(EntryEditInfo {
+                            action: EntryEditAction::Create,
+                            entry,
+                        }),
                     }
                 })
             }
@@ -116,7 +119,10 @@ impl RunningEntry {
                         let client = Client::from_api_token(&token);
                         match entry.stop(&client).await {
                             Err(e) => Error(e.to_string()),
-                            Ok(_) => Reload,
+                            Ok(_) => SyncUpdate(EntryEditInfo {
+                                action: EntryEditAction::Create,
+                                entry,
+                            }),
                         }
                     })
                 } else {


### PR DESCRIPTION
With new API limits in place (30 rph for free account) refreshing after every update is an unacceptable luxury